### PR TITLE
added new yard docs

### DIFF
--- a/docs/api/headers/mruby.h.html
+++ b/docs/api/headers/mruby.h.html
@@ -89,7 +89,9 @@
 <div class="tags">
   
 
-</div>Included heaers
+</div>
+
+Included heaers
 
   <h2>
     Function Summary
@@ -146,8 +148,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -236,8 +237,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -344,8 +344,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -362,8 +361,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -506,8 +504,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -542,8 +539,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -596,8 +592,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -686,7 +681,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'><p>Create a symbol.</p>
+    <span class="summary_desc"><div class='inline'><p>Creates a symbol from a C string.</p>
 </div></span>
   
 </li>
@@ -704,7 +699,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
+    <span class="summary_desc"><div class='inline'><p>Creates a symbol from a C string.</p>
 </div></span>
   
 </li>
@@ -722,8 +717,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -740,7 +734,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
+    <span class="summary_desc"><div class='inline'><p>Creates a symbol from a String.</p>
 </div></span>
   
 </li>
@@ -758,7 +752,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
+    <span class="summary_desc"><div class='inline'><p>Returns a Symbol, or nil otherwise.</p>
 </div></span>
   
 </li>
@@ -776,8 +770,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -794,7 +787,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
+    <span class="summary_desc"><div class='inline'><p>Returns a Symbol, or nil otherwise.</p>
 </div></span>
   
 </li>
@@ -812,7 +805,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
+    <span class="summary_desc"><div class='inline'><p>Returns a String from a Symbol.</p>
 </div></span>
   
 </li>
@@ -830,7 +823,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'><p>raise RuntimeError if no mem.</p>
+    <span class="summary_desc"><div class='inline'><p>Allocates the requested memory and returns a pointer to it.</p>
 </div></span>
   
 </li>
@@ -848,7 +841,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'><p>ditto.</p>
+    <span class="summary_desc"><div class='inline'><p>raise RuntimeError if no mem.</p>
 </div></span>
   
 </li>
@@ -866,7 +859,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'><p>ditto.</p>
+    <span class="summary_desc"><div class='inline'><p>Attempts to resize the memory block pointed to by ptr that was previously allocated with a call to mrb_malloc or mrb_calloc.</p>
 </div></span>
   
 </li>
@@ -884,7 +877,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'><p>return NULL if no memory available.</p>
+    <span class="summary_desc"><div class='inline'><p>Attempts to resize the memory block pointed to by ptr that was previously allocated with a call to mrb_malloc_simple.</p>
 </div></span>
   
 </li>
@@ -902,7 +895,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'><p>return NULL if no memory available.</p>
+    <span class="summary_desc"><div class='inline'><p>Allocates the requested memory and returns a pointer to it.</p>
 </div></span>
   
 </li>
@@ -920,8 +913,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'><p>return NULL if no memory available.</p>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -938,7 +930,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
+    <span class="summary_desc"><div class='inline'><p>Deallocates the memory previously allocated by a call to mrb_calloc, mrb_malloc, mrb_realloc, mrb_malloc_simple, or mrb_realloc_simple.</p>
 </div></span>
   
 </li>
@@ -956,7 +948,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
+    <span class="summary_desc"><div class='inline'><p>Returns a String from C String.</p>
 </div></span>
   
 </li>
@@ -974,7 +966,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'><p>Turns a C string into a Ruby string value.</p>
+    <span class="summary_desc"><div class='inline'><p>Returns a String from a C string.</p>
 </div></span>
   
 </li>
@@ -992,8 +984,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1100,8 +1091,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1118,15 +1108,14 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
     
       <li class="public ">
   <span class="summary_signature">
-    <a href="#mrb_toplevel_run-function" title="mrb_toplevel_run">mrb_value <strong>mrb_toplevel_run</strong>(mrb_state*, struct RProc*)</a>
+    <a href="#mrb_top_run-function" title="mrb_top_run">mrb_value <strong>mrb_top_run</strong>(mrb_state*, struct RProc*, mrb_value, unsigned)</a>
 
     
   </span>
@@ -1136,15 +1125,14 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
     
       <li class="public ">
   <span class="summary_signature">
-    <a href="#mrb_context_run-function" title="mrb_context_run">mrb_value <strong>mrb_context_run</strong>(mrb_state*, struct RProc*, mrb_value, unsigned)</a>
+    <a href="#mrb_vm_run-function" title="mrb_vm_run">mrb_value <strong>mrb_vm_run</strong>(mrb_state*, struct RProc*, mrb_value, unsigned)</a>
 
     
   </span>
@@ -1154,8 +1142,24 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
+  
+</li>
+
+    
+      <li class="public ">
+  <span class="summary_signature">
+    <a href="#mrb_vm_exec-function" title="mrb_vm_exec">mrb_value <strong>mrb_vm_exec</strong>(mrb_state*, struct RProc*, mrb_code*)</a>
+
+    
+  </span>
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1172,8 +1176,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1190,8 +1193,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1208,8 +1210,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1226,8 +1227,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1244,8 +1244,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1262,8 +1261,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1280,8 +1278,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1298,8 +1295,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1316,8 +1312,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1334,8 +1329,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1352,8 +1346,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1370,8 +1363,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1388,8 +1380,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1406,8 +1397,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1424,8 +1414,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1442,8 +1431,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1460,8 +1448,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1478,8 +1465,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1496,8 +1482,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1514,8 +1499,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1532,8 +1516,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1550,8 +1533,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1568,8 +1550,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1586,8 +1567,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1604,8 +1584,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1622,8 +1601,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1640,8 +1618,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1658,8 +1635,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1676,8 +1652,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1694,8 +1669,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1712,8 +1686,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1730,8 +1703,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1748,8 +1720,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1766,8 +1737,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1784,8 +1754,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1802,8 +1771,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1820,8 +1788,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1838,8 +1805,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1856,8 +1822,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1928,8 +1893,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1946,8 +1910,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1964,8 +1927,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -1982,8 +1944,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -2000,8 +1961,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -2018,8 +1978,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -2036,8 +1995,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -2090,8 +2048,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -2108,8 +2065,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -2126,8 +2082,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -2144,8 +2099,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -2162,8 +2116,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -2180,8 +2133,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -2198,8 +2150,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -2216,8 +2167,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -2234,8 +2184,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -2252,8 +2201,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'>
-</div></span>
+    <span class="summary_desc"><div class='inline'></div></span>
   
 </li>
 
@@ -2286,6 +2234,8 @@
   
 
 </div>
+
+
       </dt>
       <dd><pre class="code"></pre></dd>
     
@@ -2301,6 +2251,8 @@
   
 
 </div>
+
+
       </dt>
       <dd><pre class="code"></pre></dd>
     
@@ -2316,6 +2268,8 @@
   
 
 </div>
+
+
       </dt>
       <dd><pre class="code"></pre></dd>
     
@@ -2331,6 +2285,8 @@
   
 
 </div>
+
+
       </dt>
       <dd><pre class="code"></pre></dd>
     
@@ -2346,6 +2302,8 @@
   
 
 </div>
+
+
       </dt>
       <dd><pre class="code"></pre></dd>
     
@@ -2361,6 +2319,8 @@
   
 
 </div>
+
+
       </dt>
       <dd><pre class="code"></pre></dd>
     
@@ -2376,6 +2336,8 @@
   
 
 </div>
+
+
       </dt>
       <dd><pre class="code"></pre></dd>
     
@@ -2391,6 +2353,8 @@
   
 
 </div>
+
+
       </dt>
       <dd><pre class="code"></pre></dd>
     
@@ -2406,6 +2370,8 @@
   
 
 </div>
+
+
       </dt>
       <dd><pre class="code"></pre></dd>
     
@@ -2415,8 +2381,8 @@
     <p><code>strlen</code> for character string literals (use with caution or <code>strlen</code> instead)
    Adjacent string literals are concatenated in C/C++ in translation phase 6.
    If <code>lit</code> is not one, the compiler will report a syntax error:
-    MSVC: “error C2143: syntax error : missing ‘)’ before ‘string’”
-    GCC:  “error: expected ‘)’ before string constant”</p>
+    MSVC: &quot;error C2143: syntax error : missing &#39;)&#39; before &#39;string&#39;&quot;
+    GCC:  &quot;error: expected &#39;)&#39; before string constant&quot;</p>
 
 
   </div>
@@ -2425,6 +2391,8 @@
   
 
 </div>
+
+
       </dt>
       <dd><pre class="code"></pre></dd>
     
@@ -2454,6 +2422,33 @@
       <dd><pre class="code"></pre></dd>
     
       <dt id="mrb_locale_from_utf8-define" class=""><small>#define</small> mrb_locale_from_utf8
+        
+      </dt>
+      <dd><pre class="code"></pre></dd>
+    
+      <dt id="mrb_toplevel_run_keep-define" class=""><small>#define</small> mrb_toplevel_run_keep
+        <div class="docstring">
+  <div class="discussion">
+    <p>compatibility macros</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+
+</div>
+
+
+      </dt>
+      <dd><pre class="code"></pre></dd>
+    
+      <dt id="mrb_toplevel_run-define" class=""><small>#define</small> mrb_toplevel_run
+        
+      </dt>
+      <dd><pre class="code"></pre></dd>
+    
+      <dt id="mrb_context_run-define" class=""><small>#define</small> mrb_context_run
         
       </dt>
       <dd><pre class="code"></pre></dd>
@@ -2527,9 +2522,12 @@
         <div class="docstring">
   <div class="discussion">
     <p>macros to get typical exception objects
-  note:
-  + those E_* macros requires mrb_state* variable named mrb.
-  + exception objects obtained from those macros are local to mrb</p>
+  note:</p>
+
+<ul>
+<li>those E_* macros requires mrb_state* variable named mrb.</li>
+<li>exception objects obtained from those macros are local to mrb</li>
+</ul>
 
 
   </div>
@@ -2538,6 +2536,8 @@
   
 
 </div>
+
+
       </dt>
       <dd><pre class="code"></pre></dd>
     
@@ -2628,6 +2628,10 @@
   
 
 </div>
+
+	<p class="tag_title"><strong>Required mrbgem</strong>: mruby-fiber</p>
+
+
       </dt>
       <dd><pre class="code"></pre></dd>
     
@@ -2648,6 +2652,195 @@
     
   </dl>
 
+
+  <h2>Typedef Summary</h2>
+  <dl class="constants">
+    
+      <dt id="mrb_code-typedef" class=""><small>typedef</small> mrb_code
+        <div class="docstring">
+  <div class="discussion">
+    <p>MRuby C API entry point</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+
+</div>
+
+
+      </dt>
+      <dd><pre class="code"></pre></dd>
+    
+      <dt id="mrb_aspec-typedef" class=""><small>typedef</small> mrb_aspec
+        <div class="docstring">
+  <div class="discussion">
+    <p>Required arguments signature type.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+
+</div>
+
+
+      </dt>
+      <dd><pre class="code"></pre></dd>
+    
+      <dt id="mrb_args_format-typedef" class=""><small>typedef</small> mrb_args_format
+        <div class="docstring">
+  <div class="discussion">
+    <p>Format specifiers for <span class='object_link'><a href="#mrb_get_args-function" title="mrb_get_args (function)">mrb_get_args</a></span> function</p>
+
+<p>Must be a C string composed of the following format specifiers:</p>
+
+<table><thead>
+<tr>
+<th style="text-align: center">char</th>
+<th>Ruby type</th>
+<th>C types</th>
+<th>Notes</th>
+</tr>
+</thead><tbody>
+<tr>
+<td style="text-align: center"><code>o</code></td>
+<td><span class='object_link'><a href="../Object.html" title="Object (class)">Object</a></span></td>
+<td><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></td>
+<td>Could be used to retrieve any type of argument</td>
+</tr>
+<tr>
+<td style="text-align: center"><code>C</code></td>
+<td>Class/<span class='object_link'><a href="../Module.html" title="Module (class)">Module</a></span></td>
+<td><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></td>
+<td></td>
+</tr>
+<tr>
+<td style="text-align: center"><code>S</code></td>
+<td><span class='object_link'><a href="../String.html" title="String (class)">String</a></span></td>
+<td><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></td>
+<td>when <code>!</code> follows, the value may be <code>nil</code></td>
+</tr>
+<tr>
+<td style="text-align: center"><code>A</code></td>
+<td><span class='object_link'><a href="../Array.html" title="Array (class)">Array</a></span></td>
+<td><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></td>
+<td>when <code>!</code> follows, the value may be <code>nil</code></td>
+</tr>
+<tr>
+<td style="text-align: center"><code>H</code></td>
+<td><span class='object_link'><a href="../Hash.html" title="Hash (class)">Hash</a></span></td>
+<td><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></td>
+<td>when <code>!</code> follows, the value may be <code>nil</code></td>
+</tr>
+<tr>
+<td style="text-align: center"><code>s</code></td>
+<td><span class='object_link'><a href="../String.html" title="String (class)">String</a></span></td>
+<td>char *, <span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_int-typedef" title="mrb_int (typedef)">mrb_int</a></span></td>
+<td>Receive two arguments; <code>s!</code> gives (<code>NULL</code>,<code>0</code>) for <code>nil</code></td>
+</tr>
+<tr>
+<td style="text-align: center"><code>z</code></td>
+<td><span class='object_link'><a href="../String.html" title="String (class)">String</a></span></td>
+<td>char *</td>
+<td><code>NULL</code> terminated string; <code>z!</code> gives <code>NULL</code> for <code>nil</code></td>
+</tr>
+<tr>
+<td style="text-align: center"><code>a</code></td>
+<td><span class='object_link'><a href="../Array.html" title="Array (class)">Array</a></span></td>
+<td><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span> *, <span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_int-typedef" title="mrb_int (typedef)">mrb_int</a></span></td>
+<td>Receive two arguments; <code>a!</code> gives (<code>NULL</code>,<code>0</code>) for <code>nil</code></td>
+</tr>
+<tr>
+<td style="text-align: center"><code>f</code></td>
+<td><span class='object_link'><a href="../Float.html" title="Float (class)">Float</a></span></td>
+<td><span class='object_link'><a href="mruby_2Fboxing_no.h.html#mrb_float-define" title="mrb_float (define)">mrb_float</a></span></td>
+<td></td>
+</tr>
+<tr>
+<td style="text-align: center"><code>i</code></td>
+<td><span class='object_link'><a href="../Integer.html" title="Integer (class)">Integer</a></span></td>
+<td><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_int-typedef" title="mrb_int (typedef)">mrb_int</a></span></td>
+<td></td>
+</tr>
+<tr>
+<td style="text-align: center"><code>b</code></td>
+<td>boolean</td>
+<td><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_bool-define" title="mrb_bool (define)">mrb_bool</a></span></td>
+<td></td>
+</tr>
+<tr>
+<td style="text-align: center"><code>n</code></td>
+<td><span class='object_link'><a href="../Symbol.html" title="Symbol (class)">Symbol</a></span></td>
+<td><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_sym-typedef" title="mrb_sym (typedef)">mrb_sym</a></span></td>
+<td></td>
+</tr>
+<tr>
+<td style="text-align: center"><code>&amp;</code></td>
+<td>block</td>
+<td><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></td>
+<td></td>
+</tr>
+<tr>
+<td style="text-align: center"><code>*</code></td>
+<td>rest arguments</td>
+<td><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span> *, <span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_int-typedef" title="mrb_int (typedef)">mrb_int</a></span></td>
+<td>Receive the rest of arguments as an array.</td>
+</tr>
+<tr>
+<td style="text-align: center">&vert;</td>
+<td>optional</td>
+<td></td>
+<td>After this spec following specs would be optional.</td>
+</tr>
+<tr>
+<td style="text-align: center"><code>?</code></td>
+<td>optional given</td>
+<td><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_bool-define" title="mrb_bool (define)">mrb_bool</a></span></td>
+<td><code>TRUE</code> if preceding argument is given. Used to check optional argument is given.</td>
+</tr>
+</tbody></table>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+
+  <p class="tag_title">See Also:</p>
+  <ul class="see">
+    
+      <li><span class='object_link'><a href="#mrb_get_args-function" title="mrb_get_args (function)">mrb_get_args</a></span></li>
+    
+  </ul>
+
+</div>
+
+
+      </dt>
+      <dd><pre class="code"></pre></dd>
+    
+      <dt id="mrb_pool-typedef" class=""><small>typedef</small> mrb_pool
+        <div class="docstring">
+  <div class="discussion">
+    <p>memory pool implementation</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+
+</div>
+
+
+      </dt>
+      <dd><pre class="code"></pre></dd>
+    
+  </dl>
+
 <div id="functions_details" class="method_details_list">
   <h2>Function Details</h2>
 
@@ -2662,15 +2855,15 @@
   <div class="discussion">
     <p>Defines a new class.</p>
 
-<p>If you’re creating a gem it may look something like this:</p>
+<p>If you&#39;re creating a gem it may look something like this:</p>
 
-<pre class="code c"><code class="c"> void mrb_example_gem_init(mrb_state* mrb) {
-     struct RClass *example_class;
-     example_class = mrb_define_class(mrb, &quot;Example_Class&quot;, mrb-&gt;object_class);
+<pre class="code c"><code class="c"> <span style="color:#088;font-weight:bold">void</span> mrb_example_gem_init(mrb_state* mrb) {
+     <span style="color:#080;font-weight:bold">struct</span> RClass *example_class;
+     example_class = mrb_define_class(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">Example_Class</span><span style="color:#710">&quot;</span></span>, mrb-&gt;object_class);
  }
 
- void mrb_example_gem_final(mrb_state* mrb) {
-     //free(TheAnimals);
+ <span style="color:#088;font-weight:bold">void</span> mrb_example_gem_final(mrb_state* mrb) {
+     <span style="color:#777">//free(TheAnimals);</span>
  }
 </code></pre>
 
@@ -2754,6 +2947,8 @@
   </ul>
 
 </div>
+
+
 </div>
 
   
@@ -2825,6 +3020,8 @@
 </ul>
 
 </div>
+
+
 </div>
 
   
@@ -2909,6 +3106,8 @@ Equivalent to:</p>
 
 
 </div>
+
+
 </div>
 
   
@@ -2983,6 +3182,8 @@ Equivalent to:</p>
 
 
 </div>
+
+
 </div>
 
   
@@ -2996,19 +3197,19 @@ Equivalent to:</p>
   <div class="discussion">
     <p>Defines a global function in ruby.</p>
 
-<p>If you’re creating a gem it may look something like this</p>
+<p>If you&#39;re creating a gem it may look something like this</p>
 
 <p>Example:</p>
 
 <pre class="code c"><code class="c">mrb_value example_method(mrb_state* mrb, mrb_value self)
 {
-     puts(&quot;Executing example command!&quot;);
-     return self;
+     puts(<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">Executing example command!</span><span style="color:#710">&quot;</span></span>);
+     <span style="color:#080;font-weight:bold">return</span> self;
 }
 
-void mrb_example_gem_init(mrb_state* mrb)
+<span style="color:#088;font-weight:bold">void</span> mrb_example_gem_init(mrb_state* mrb)
 {
-      mrb_define_method(mrb, mrb-&gt;kernel_module, &quot;example_method&quot;, example_method, MRB_ARGS_NONE());
+      mrb_define_method(mrb, mrb-&gt;kernel_module, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">example_method</span><span style="color:#710">&quot;</span></span>, example_method, MRB_ARGS_NONE());
 }
 </code></pre>
 
@@ -3084,7 +3285,7 @@ void mrb_example_gem_init(mrb_state* mrb)
         <span class='name'>aspec</span>
       
       
-        <span class='type'>(<tt>mrb_aspec</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="#mrb_aspec-typedef" title="mrb_aspec (typedef)">mrb_aspec</a></span></tt>)</span>
       
       
       
@@ -3098,6 +3299,8 @@ void mrb_example_gem_init(mrb_state* mrb)
 
 
 </div>
+
+
 </div>
 
   
@@ -3113,19 +3316,19 @@ void mrb_example_gem_init(mrb_state* mrb)
 
 <p>Example:</p>
 
-<pre class="code ruby"><code class="ruby"># Ruby style
-class Foo
-  def Foo.bar
-  end
-end
-// C style
-mrb_value bar_method(mrb_state* mrb, mrb_value self){
-  return mrb_nil_value();
+<pre class="code ruby"><code class="ruby"><span style="color:#777"># Ruby way</span>
+<span style="color:#080;font-weight:bold">class</span> <span style="color:#B06;font-weight:bold">Foo</span>
+  <span style="color:#080;font-weight:bold">def</span> <span style="color:#036;font-weight:bold">Foo</span>.<span style="color:#06B;font-weight:bold">bar</span>
+  <span style="color:#080;font-weight:bold">end</span>
+<span style="color:#080;font-weight:bold">end</span>
+<span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">C</span> way
+mrb_value bar_method(mrb_state* mrb, mrb_value <span style="color:#069">self</span>){
+  <span style="color:#080;font-weight:bold">return</span> mrb_nil_value();
 }
 void mrb_example_gem_init(mrb_state* mrb){
-  struct RClass *foo;
-  foo = mrb_define_class(mrb, &quot;Foo&quot;, mrb-&gt;object_class);
-  mrb_define_class_method(mrb, foo, &quot;bar&quot;, bar_method, MRB_ARGS_NONE());
+  struct <span style="color:#036;font-weight:bold">RClass</span> *foo;
+  foo = mrb_define_class(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">Foo</span><span style="color:#710">&quot;</span></span>, mrb-&gt;object_class);
+  mrb_define_class_method(mrb, foo, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">bar</span><span style="color:#710">&quot;</span></span>, bar_method, MRB_ARGS_NONE());
 }
 </code></pre>
 
@@ -3201,7 +3404,7 @@ void mrb_example_gem_init(mrb_state* mrb){
         <span class='name'>mrb_aspec</span>
       
       
-        <span class='type'>(<tt>mrb_aspec</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="#mrb_aspec-typedef" title="mrb_aspec (typedef)">mrb_aspec</a></span></tt>)</span>
       
       
       
@@ -3215,6 +3418,8 @@ void mrb_example_gem_init(mrb_state* mrb){
 
 
 </div>
+
+
 </div>
 
   
@@ -3240,19 +3445,19 @@ void mrb_example_gem_init(mrb_state* mrb){
 
 <p>Example:</p>
 
-<pre class="code ruby"><code class="ruby">  # Ruby style
-  module Foo
-    def Foo.bar
-    end
-  end
-  // C style
-  mrb_value bar_method(mrb_state* mrb, mrb_value self){
-    return mrb_nil_value();
+<pre class="code ruby"><code class="ruby">  <span style="color:#777"># Ruby way</span>
+  <span style="color:#080;font-weight:bold">module</span> <span style="color:#B06;font-weight:bold">Foo</span>
+    <span style="color:#080;font-weight:bold">def</span> <span style="color:#036;font-weight:bold">Foo</span>.<span style="color:#06B;font-weight:bold">bar</span>
+    <span style="color:#080;font-weight:bold">end</span>
+  <span style="color:#080;font-weight:bold">end</span>
+  <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">C</span> way
+  mrb_value bar_method(mrb_state* mrb, mrb_value <span style="color:#069">self</span>){
+    <span style="color:#080;font-weight:bold">return</span> mrb_nil_value();
   }
   void mrb_example_gem_init(mrb_state* mrb){
-    struct RClass *foo;
-    foo = mrb_define_module(mrb, &quot;Foo&quot;);
-    mrb_define_module_function(mrb, foo, &quot;bar&quot;, bar_method, MRB_ARGS_NONE());
+    struct <span style="color:#036;font-weight:bold">RClass</span> *foo;
+    foo = mrb_define_module(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">Foo</span><span style="color:#710">&quot;</span></span>);
+    mrb_define_module_function(mrb, foo, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">bar</span><span style="color:#710">&quot;</span></span>, bar_method, MRB_ARGS_NONE());
   }
 </code></pre>
 
@@ -3328,7 +3533,7 @@ void mrb_example_gem_init(mrb_state* mrb){
         <span class='name'>mrb_aspec</span>
       
       
-        <span class='type'>(<tt>mrb_aspec</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="#mrb_aspec-typedef" title="mrb_aspec (typedef)">mrb_aspec</a></span></tt>)</span>
       
       
       
@@ -3342,6 +3547,8 @@ void mrb_example_gem_init(mrb_state* mrb){
 
 
 </div>
+
+
 </div>
 
   
@@ -3357,17 +3564,17 @@ void mrb_example_gem_init(mrb_state* mrb){
 
 <p>Example:</p>
 
-<pre class="code ruby"><code class="ruby">    # Ruby style
-    class ExampleClass
-      AGE = 22
-    end
-    // C style
-    #include &lt;stdio.h&gt;
-    #include &lt;mruby.h&gt;
+<pre class="code ruby"><code class="ruby">    <span style="color:#777"># Ruby way</span>
+    <span style="color:#080;font-weight:bold">class</span> <span style="color:#B06;font-weight:bold">ExampleClass</span>
+      <span style="color:#036;font-weight:bold">AGE</span> = <span style="color:#00D">22</span>
+    <span style="color:#080;font-weight:bold">end</span>
+    <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">C</span> way
+    <span style="color:#777">#include &lt;stdio.h&gt;</span>
+    <span style="color:#777">#include &lt;mruby.h&gt;</span>
 
     void
     mrb_example_gem_init(mrb_state* mrb){
-      mrb_define_const(mrb, mrb-&gt;kernel_module, &quot;AGE&quot;, mrb_fixnum_value(22));
+      mrb_define_const(mrb, mrb-&gt;kernel_module, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">AGE</span><span style="color:#710">&quot;</span></span>, mrb_fixnum_value(<span style="color:#00D">22</span>));
     }
 
     mrb_value
@@ -3432,7 +3639,7 @@ void mrb_example_gem_init(mrb_state* mrb){
         <span class='name'>mrb_value</span>
       
       
-        <span class='type'>(<tt>mrb_value</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></tt>)</span>
       
       
       
@@ -3446,6 +3653,8 @@ void mrb_example_gem_init(mrb_state* mrb){
 
 
 </div>
+
+
 </div>
 
   
@@ -3461,41 +3670,41 @@ void mrb_example_gem_init(mrb_state* mrb){
 
 <p>Example:</p>
 
-<pre class="code ruby"><code class="ruby"># Ruby style
+<pre class="code ruby"><code class="ruby"><span style="color:#777"># Ruby way</span>
 
-class ExampleClassA
-  def example_method
-    &quot;example&quot;
-  end
-end
-ExampleClassA.new.example_method # =&gt; example
+<span style="color:#080;font-weight:bold">class</span> <span style="color:#B06;font-weight:bold">ExampleClassA</span>
+  <span style="color:#080;font-weight:bold">def</span> <span style="color:#06B;font-weight:bold">example_method</span>
+    <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">example</span><span style="color:#710">&quot;</span></span>
+  <span style="color:#080;font-weight:bold">end</span>
+<span style="color:#080;font-weight:bold">end</span>
+<span style="color:#036;font-weight:bold">ExampleClassA</span>.new.example_method <span style="color:#777"># =&gt; example</span>
 
-class ExampleClassB &lt; ExampleClassA
-  undef_method :example_method
-end
+<span style="color:#080;font-weight:bold">class</span> <span style="color:#B06;font-weight:bold">ExampleClassB</span> &lt; <span style="color:#036;font-weight:bold">ExampleClassA</span>
+  undef_method <span style="color:#A60">:example_method</span>
+<span style="color:#080;font-weight:bold">end</span>
 
-ExampleClassB.new.example_method # =&gt; undefined method &#39;example_method&#39; for ExampleClassB (NoMethodError)
+<span style="color:#036;font-weight:bold">ExampleClassB</span>.new.example_method <span style="color:#777"># =&gt; undefined method 'example_method' for ExampleClassB (NoMethodError)</span>
 
-// C style
-#include &lt;stdio.h&gt;
-#include &lt;mruby.h&gt;
+<span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">C</span> way
+<span style="color:#777">#include &lt;stdio.h&gt;</span>
+<span style="color:#777">#include &lt;mruby.h&gt;</span>
 
 mrb_value
 mrb_example_method(mrb_state *mrb){
-  return mrb_str_new_cstr(mrb, &quot;example&quot;);
+  <span style="color:#080;font-weight:bold">return</span> mrb_str_new_cstr(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">example</span><span style="color:#710">&quot;</span></span>);
 }
 
 void
 mrb_example_gem_init(mrb_state* mrb){
-  struct RClass *example_class_a;
-  struct RClass *example_class_b;
-  struct RClass *example_class_c;
+  struct <span style="color:#036;font-weight:bold">RClass</span> *example_class_a;
+  struct <span style="color:#036;font-weight:bold">RClass</span> *example_class_b;
+  struct <span style="color:#036;font-weight:bold">RClass</span> *example_class_c;
 
-  example_class_a = mrb_define_class(mrb, &quot;ExampleClassA&quot;, mrb-&gt;object_class);
-  mrb_define_method(mrb, example_class_a, &quot;example_method&quot;, mrb_example_method, MRB_ARGS_NONE());
-  example_class_b = mrb_define_class(mrb, &quot;ExampleClassB&quot;, example_class_a);
-  example_class_c = mrb_define_class(mrb, &quot;ExampleClassC&quot;, example_class_b);
-  mrb_undef_method(mrb, example_class_c, &quot;example_method&quot;);
+  example_class_a = mrb_define_class(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">ExampleClassA</span><span style="color:#710">&quot;</span></span>, mrb-&gt;object_class);
+  mrb_define_method(mrb, example_class_a, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">example_method</span><span style="color:#710">&quot;</span></span>, mrb_example_method, MRB_ARGS_NONE());
+  example_class_b = mrb_define_class(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">ExampleClassB</span><span style="color:#710">&quot;</span></span>, example_class_a);
+  example_class_c = mrb_define_class(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">ExampleClassC</span><span style="color:#710">&quot;</span></span>, example_class_b);
+  mrb_undef_method(mrb, example_class_c, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">example_method</span><span style="color:#710">&quot;</span></span>);
 }
 
 mrb_example_gem_final(mrb_state* mrb){
@@ -3558,6 +3767,8 @@ mrb_example_gem_final(mrb_state* mrb){
 
 
 </div>
+
+
 </div>
 
   
@@ -3572,30 +3783,30 @@ mrb_example_gem_final(mrb_state* mrb){
     <p>Undefine a class method.
 Example:</p>
 
-<pre class="code ruby"><code class="ruby"> # Ruby style
- class ExampleClass
-   def self.example_method
-     &quot;example&quot;
-   end
- end
+<pre class="code ruby"><code class="ruby"> <span style="color:#777"># Ruby way</span>
+ <span style="color:#080;font-weight:bold">class</span> <span style="color:#B06;font-weight:bold">ExampleClass</span>
+   <span style="color:#080;font-weight:bold">def</span> <span style="color:#069">self</span>.<span style="color:#06B;font-weight:bold">example_method</span>
+     <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">example</span><span style="color:#710">&quot;</span></span>
+   <span style="color:#080;font-weight:bold">end</span>
+ <span style="color:#080;font-weight:bold">end</span>
 
-ExampleClass.example_method
+<span style="color:#036;font-weight:bold">ExampleClass</span>.example_method
 
-// C style
-#include &lt;stdio.h&gt;
-#include &lt;mruby.h&gt;
+<span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">C</span> way
+<span style="color:#777">#include &lt;stdio.h&gt;</span>
+<span style="color:#777">#include &lt;mruby.h&gt;</span>
 
 mrb_value
 mrb_example_method(mrb_state *mrb){
-  return mrb_str_new_cstr(mrb, &quot;example&quot;);
+  <span style="color:#080;font-weight:bold">return</span> mrb_str_new_cstr(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">example</span><span style="color:#710">&quot;</span></span>);
 }
 
 void
 mrb_example_gem_init(mrb_state* mrb){
-  struct RClass *example_class;
-  example_class = mrb_define_class(mrb, &quot;ExampleClass&quot;, mrb-&gt;object_class);
-  mrb_define_class_method(mrb, example_class, &quot;example_method&quot;, mrb_example_method, MRB_ARGS_NONE());
-  mrb_undef_class_method(mrb, example_class, &quot;example_method&quot;);
+  struct <span style="color:#036;font-weight:bold">RClass</span> *example_class;
+  example_class = mrb_define_class(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">ExampleClass</span><span style="color:#710">&quot;</span></span>, mrb-&gt;object_class);
+  mrb_define_class_method(mrb, example_class, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">example_method</span><span style="color:#710">&quot;</span></span>, mrb_example_method, MRB_ARGS_NONE());
+  mrb_undef_class_method(mrb, example_class, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">example_method</span><span style="color:#710">&quot;</span></span>);
  }
 
  void
@@ -3659,6 +3870,8 @@ mrb_example_gem_init(mrb_state* mrb){
 
 
 </div>
+
+
 </div>
 
   
@@ -3674,22 +3887,22 @@ mrb_example_gem_init(mrb_state* mrb){
 
 <p>Example:</p>
 
-<pre class="code ruby"><code class="ruby"># Ruby style
-class ExampleClass
-end
+<pre class="code ruby"><code class="ruby"><span style="color:#777"># Ruby way</span>
+<span style="color:#080;font-weight:bold">class</span> <span style="color:#B06;font-weight:bold">ExampleClass</span>
+<span style="color:#080;font-weight:bold">end</span>
 
-p ExampleClass # =&gt; #&lt;ExampleClass:0x9958588&gt;
-// C style
-#include &lt;stdio.h&gt;
-#include &lt;mruby.h&gt;
+p <span style="color:#036;font-weight:bold">ExampleClass</span> <span style="color:#777"># =&gt; #&lt;ExampleClass:0x9958588&gt;</span>
+<span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">C</span> way
+<span style="color:#777">#include &lt;stdio.h&gt;</span>
+<span style="color:#777">#include &lt;mruby.h&gt;</span>
 
 void
 mrb_example_gem_init(mrb_state* mrb) {
-  struct RClass *example_class;
+  struct <span style="color:#036;font-weight:bold">RClass</span> *example_class;
   mrb_value obj;
-  example_class = mrb_define_class(mrb, &quot;ExampleClass&quot;, mrb-&gt;object_class); # =&gt; class ExampleClass; end
-  obj = mrb_obj_new(mrb, example_class, 0, NULL); # =&gt; ExampleClass.new
-  mrb_p(mrb, obj); // =&gt; Kernel#p
+  example_class = mrb_define_class(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">ExampleClass</span><span style="color:#710">&quot;</span></span>, mrb-&gt;object_class); <span style="color:#777"># =&gt; class ExampleClass; end</span>
+  obj = mrb_obj_new(mrb, example_class, <span style="color:#00D">0</span>, <span style="color:#036;font-weight:bold">NULL</span>); <span style="color:#777"># =&gt; ExampleClass.new</span>
+  mrb_p(mrb, obj); <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> =&gt; <span style="color:#036;font-weight:bold">Kernel</span><span style="color:#777">#p</span>
  }
 </code></pre>
 
@@ -3735,7 +3948,7 @@ mrb_example_gem_init(mrb_state* mrb) {
         <span class='name'>argc</span>
       
       
-        <span class='type'>(<tt><span class='object_link'><a href="#mrb_int-define" title="mrb_int (define)">mrb_int</a></span></tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_int-typedef" title="mrb_int (typedef)">mrb_int</a></span></tt>)</span>
       
       
       
@@ -3750,7 +3963,7 @@ mrb_example_gem_init(mrb_state* mrb) {
         <span class='name'>argv</span>
       
       
-        <span class='type'>(<tt>const mrb_value *</tt>)</span>
+        <span class='type'>(<tt>const <span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span> *</tt>)</span>
       
       
       
@@ -3768,7 +3981,7 @@ mrb_example_gem_init(mrb_state* mrb) {
     <li>
       
       
-        <span class='type'>(<tt>mrb_value</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></tt>)</span>
       
       
       
@@ -3781,6 +3994,8 @@ mrb_example_gem_init(mrb_state* mrb) {
 </ul>
 
 </div>
+
+
 </div>
 
   
@@ -3793,7 +4008,6 @@ mrb_example_gem_init(mrb_state* mrb) {
 <div class="docstring">
   <div class="discussion">
     
-
 
   </div>
 </div>
@@ -3808,6 +4022,8 @@ mrb_example_gem_init(mrb_state* mrb) {
   </ul>
 
 </div>
+
+
 </div>
 
   
@@ -3835,12 +4051,12 @@ mrb_example_gem_init(mrb_state* mrb) {
 
 <pre class="code ruby"><code class="ruby"> void
  mrb_example_gem_init(mrb_state* mrb) {
-   struct RClass *example_class;
+   struct <span style="color:#036;font-weight:bold">RClass</span> *example_class;
 
    mrb_value obj;
    example_class = mrb_class_new(mrb, mrb-&gt;object_class);
-   obj = mrb_obj_new(mrb, example_class, 0, NULL); // =&gt; #&lt;#&lt;Class:0x9a945b8&gt;:0x9a94588&gt;
-   mrb_p(mrb, obj); // =&gt; Kernel#p
+   obj = mrb_obj_new(mrb, example_class, <span style="color:#00D">0</span>, <span style="color:#036;font-weight:bold">NULL</span>); <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> =&gt; <span style="color:#777">#&lt;#&lt;Class:0x9a945b8&gt;:0x9a94588&gt;</span>
+   mrb_p(mrb, obj); <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> =&gt; <span style="color:#036;font-weight:bold">Kernel</span><span style="color:#777">#p</span>
   }
 </code></pre>
 
@@ -3902,6 +4118,8 @@ mrb_example_gem_init(mrb_state* mrb) {
 </ul>
 
 </div>
+
+
 </div>
 
   
@@ -3967,6 +4185,8 @@ mrb_example_gem_init(mrb_state* mrb) {
 </ul>
 
 </div>
+
+
 </div>
 
   
@@ -3986,16 +4206,16 @@ mrb_example_gem_init(mrb_state* mrb) {
       struct RClass *example_class;
       mrb_bool cd;</p>
 
-<pre class="code ruby"><code class="ruby">  example_class = mrb_define_class(mrb, &quot;ExampleClass&quot;, mrb-&gt;object_class);
-  cd = mrb_class_defined(mrb, &quot;ExampleClass&quot;);
+<pre class="code ruby"><code class="ruby">  example_class = mrb_define_class(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">ExampleClass</span><span style="color:#710">&quot;</span></span>, mrb-&gt;object_class);
+  cd = mrb_class_defined(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">ExampleClass</span><span style="color:#710">&quot;</span></span>);
 
-  // If mrb_class_defined returns 1 then puts &quot;True&quot;
-  // If mrb_class_defined returns 0 then puts &quot;False&quot;
-  if (cd == 1){
-    puts(&quot;True&quot;);
+  <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">If</span> mrb_class_defined returns <span style="color:#00D">1</span> <span style="color:#080;font-weight:bold">then</span> puts <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">True</span><span style="color:#710">&quot;</span></span>
+  <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">If</span> mrb_class_defined returns <span style="color:#00D">0</span> <span style="color:#080;font-weight:bold">then</span> puts <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">False</span><span style="color:#710">&quot;</span></span>
+  <span style="color:#080;font-weight:bold">if</span> (cd == <span style="color:#00D">1</span>){
+    puts(<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">True</span><span style="color:#710">&quot;</span></span>);
   }
-  else {
-    puts(&quot;False&quot;);
+  <span style="color:#080;font-weight:bold">else</span> {
+    puts(<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">False</span><span style="color:#710">&quot;</span></span>);
   }
  }
 </code></pre>
@@ -4058,6 +4278,8 @@ mrb_example_gem_init(mrb_state* mrb) {
 </ul>
 
 </div>
+
+
 </div>
 
   
@@ -4129,6 +4351,8 @@ mrb_example_gem_init(mrb_state* mrb) {
 </ul>
 
 </div>
+
+
 </div>
 
   
@@ -4215,6 +4439,8 @@ mrb_example_gem_init(mrb_state* mrb) {
 </ul>
 
 </div>
+
+
 </div>
 
   
@@ -4286,6 +4512,8 @@ mrb_example_gem_init(mrb_state* mrb) {
 </ul>
 
 </div>
+
+
 </div>
 
   
@@ -4372,6 +4600,8 @@ mrb_example_gem_init(mrb_state* mrb) {
 </ul>
 
 </div>
+
+
 </div>
 
   
@@ -4425,7 +4655,7 @@ mrb_example_gem_init(mrb_state* mrb) {
         <span class='name'>obj</span>
       
       
-        <span class='type'>(<tt>mrb_value</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></tt>)</span>
       
       
       
@@ -4443,7 +4673,7 @@ mrb_example_gem_init(mrb_state* mrb) {
     <li>
       
       
-        <span class='type'>(<tt>mrb_value</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></tt>)</span>
       
       
       
@@ -4456,6 +4686,8 @@ mrb_example_gem_init(mrb_state* mrb) {
 </ul>
 
 </div>
+
+
 </div>
 
   
@@ -4480,34 +4712,34 @@ mrb_example_gem_init(mrb_state* mrb) {
     <p>Returns true if obj responds to the given method. If the method was defined for that
 class it returns true, it returns false otherwise.</p>
 
-<pre class="code ruby"><code class="ruby"> Example:
- # Ruby style
- class ExampleClass
-   def example_method
-   end
- end
+<pre class="code ruby"><code class="ruby"> <span style="color:#606">Example</span>:
+ <span style="color:#777"># Ruby way</span>
+ <span style="color:#080;font-weight:bold">class</span> <span style="color:#B06;font-weight:bold">ExampleClass</span>
+   <span style="color:#080;font-weight:bold">def</span> <span style="color:#06B;font-weight:bold">example_method</span>
+   <span style="color:#080;font-weight:bold">end</span>
+ <span style="color:#080;font-weight:bold">end</span>
 
- ExampleClass.new.respond_to?(:example_method) # =&gt; true
+ <span style="color:#036;font-weight:bold">ExampleClass</span>.new.respond_to?(<span style="color:#A60">:example_method</span>) <span style="color:#777"># =&gt; true</span>
 
- // C style
+ <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">C</span> way
  void
  mrb_example_gem_init(mrb_state* mrb) {
-   struct RClass *example_class;
+   struct <span style="color:#036;font-weight:bold">RClass</span> *example_class;
    mrb_sym mid;
    mrb_bool obj_resp;
 
-   example_class = mrb_define_class(mrb, &quot;ExampleClass&quot;, mrb-&gt;object_class);
-   mrb_define_method(mrb, example_class, &quot;example_method&quot;, exampleMethod, MRB_ARGS_NONE());
-   mid = mrb_intern_str(mrb, mrb_str_new_cstr(mrb, &quot;example_method&quot; ));
-   obj_resp = mrb_obj_respond_to(mrb, example_class, mid); // =&gt; 1(true in Ruby world)
+   example_class = mrb_define_class(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">ExampleClass</span><span style="color:#710">&quot;</span></span>, mrb-&gt;object_class);
+   mrb_define_method(mrb, example_class, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">example_method</span><span style="color:#710">&quot;</span></span>, exampleMethod, MRB_ARGS_NONE());
+   mid = mrb_intern_str(mrb, mrb_str_new_cstr(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">example_method</span><span style="color:#710">&quot;</span></span> ));
+   obj_resp = mrb_obj_respond_to(mrb, example_class, mid); <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> =&gt; <span style="color:#00D">1</span>(<span style="color:#069">true</span> <span style="color:#080;font-weight:bold">in</span> <span style="color:#036;font-weight:bold">Ruby</span> world)
 
-   // If mrb_obj_respond_to returns 1 then puts &quot;True&quot;
-   // If mrb_obj_respond_to returns 0 then puts &quot;False&quot;
-   if (obj_resp == 1) {
-     puts(&quot;True&quot;);
+   <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">If</span> mrb_obj_respond_to returns <span style="color:#00D">1</span> <span style="color:#080;font-weight:bold">then</span> puts <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">True</span><span style="color:#710">&quot;</span></span>
+   <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">If</span> mrb_obj_respond_to returns <span style="color:#00D">0</span> <span style="color:#080;font-weight:bold">then</span> puts <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">False</span><span style="color:#710">&quot;</span></span>
+   <span style="color:#080;font-weight:bold">if</span> (obj_resp == <span style="color:#00D">1</span>) {
+     puts(<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">True</span><span style="color:#710">&quot;</span></span>);
    }
-   else if (obj_resp == 0) {
-     puts(&quot;False&quot;);
+   <span style="color:#080;font-weight:bold">else</span> <span style="color:#080;font-weight:bold">if</span> (obj_resp == <span style="color:#00D">0</span>) {
+     puts(<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">False</span><span style="color:#710">&quot;</span></span>);
    }
  }
 </code></pre>
@@ -4554,7 +4786,7 @@ class it returns true, it returns false otherwise.</p>
         <span class='name'>mid</span>
       
       
-        <span class='type'>(<tt>mrb_sym</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_sym-typedef" title="mrb_sym (typedef)">mrb_sym</a></span></tt>)</span>
       
       
       
@@ -4585,6 +4817,8 @@ class it returns true, it returns false otherwise.</p>
 </ul>
 
 </div>
+
+
 </div>
 
   
@@ -4693,6 +4927,8 @@ class it returns true, it returns false otherwise.</p>
   </ul>
 
 </div>
+
+
 </div>
 
   
@@ -4747,7 +4983,7 @@ Used inside a function of mrb_func_t type.</p>
         <span class='name'>format</span>
       
       
-        <span class='type'>(<tt>mrb_args_format</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="#mrb_args_format-typedef" title="mrb_args_format (typedef)">mrb_args_format</a></span></tt>)</span>
       
       
       
@@ -4795,11 +5031,13 @@ Used inside a function of mrb_func_t type.</p>
   <p class="tag_title">See Also:</p>
   <ul class="see">
     
-      <li>mruby.h.mrb_args_format</li>
+      <li><span class='object_link'><a href="#mrb_args_format-typedef" title="mrb_args_format (typedef)">mrb_args_format</a></span></li>
     
   </ul>
 
 </div>
+
+
 </div>
 
   
@@ -4813,20 +5051,20 @@ Used inside a function of mrb_func_t type.</p>
   <div class="discussion">
     <p>Call existing ruby functions.</p>
 
-<pre class="code ruby"><code class="ruby"> #include &lt;stdio.h&gt;
- #include &lt;mruby.h&gt;
- #include &quot;mruby/compile.h&quot;
+<pre class="code ruby"><code class="ruby"> <span style="color:#777">#include &lt;stdio.h&gt;</span>
+ <span style="color:#777">#include &lt;mruby.h&gt;</span>
+ <span style="color:#777">#include &quot;mruby/compile.h&quot;</span>
 
  int
  main()
  {
-   mrb_int i = 99;
+   mrb_int i = <span style="color:#00D">99</span>;
    mrb_state *mrb = mrb_open();
 
-   if (!mrb) { }
-   FILE *fp = fopen(&quot;test.rb&quot;,&quot;r&quot;);
+   <span style="color:#080;font-weight:bold">if</span> (!mrb) { }
+   <span style="color:#036;font-weight:bold">FILE</span> *fp = fopen(<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">test.rb</span><span style="color:#710">&quot;</span></span>,<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">r</span><span style="color:#710">&quot;</span></span>);
    mrb_value obj = mrb_load_file(mrb,fp);
-   mrb_funcall(mrb, obj, &quot;method_name&quot;, 1, mrb_fixnum_value(i));
+   mrb_funcall(mrb, obj, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">method_name</span><span style="color:#710">&quot;</span></span>, <span style="color:#00D">1</span>, mrb_fixnum_value(i));
    fclose(fp);
    mrb_close(mrb);
   }
@@ -4859,7 +5097,7 @@ Used inside a function of mrb_func_t type.</p>
         <span class='name'>mrb_value</span>
       
       
-        <span class='type'>(<tt>mrb_value</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></tt>)</span>
       
       
       
@@ -4889,7 +5127,7 @@ Used inside a function of mrb_func_t type.</p>
         <span class='name'>mrb_int</span>
       
       
-        <span class='type'>(<tt><span class='object_link'><a href="#mrb_int-define" title="mrb_int (define)">mrb_int</a></span></tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_int-typedef" title="mrb_int (typedef)">mrb_int</a></span></tt>)</span>
       
       
       
@@ -4922,7 +5160,7 @@ Used inside a function of mrb_func_t type.</p>
     <li>
       
       
-        <span class='type'>(<tt>mrb_value</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></tt>)</span>
       
       
       
@@ -4935,6 +5173,8 @@ Used inside a function of mrb_func_t type.</p>
 </ul>
 
 </div>
+
+
 </div>
 
   
@@ -4948,21 +5188,21 @@ Used inside a function of mrb_func_t type.</p>
   <div class="discussion">
     <p>Call existing ruby functions. This is basically the type safe version of mrb_funcall.</p>
 
-<pre class="code ruby"><code class="ruby"> #include &lt;stdio.h&gt;
- #include &lt;mruby.h&gt;
- #include &quot;mruby/compile.h&quot;
+<pre class="code ruby"><code class="ruby"> <span style="color:#777">#include &lt;stdio.h&gt;</span>
+ <span style="color:#777">#include &lt;mruby.h&gt;</span>
+ <span style="color:#777">#include &quot;mruby/compile.h&quot;</span>
  int
  main()
  {
-   mrb_int i = 99;
+   mrb_int i = <span style="color:#00D">99</span>;
    mrb_state *mrb = mrb_open();
 
-   if (!mrb) { }
-   mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;method_name&quot;); // Symbol for method.
+   <span style="color:#080;font-weight:bold">if</span> (!mrb) { }
+   mrb_sym m_sym = mrb_intern_cstr(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">method_name</span><span style="color:#710">&quot;</span></span>); <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">Symbol</span> <span style="color:#080;font-weight:bold">for</span> method.
 
-   FILE *fp = fopen(&quot;test.rb&quot;,&quot;r&quot;);
+   FILE *fp = fopen(<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">test.rb</span><span style="color:#710">&quot;</span></span>,<span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">r</span><span style="color:#710">&quot;</span></span>);
    mrb_value obj = mrb_load_file(mrb,fp);
-   mrb_funcall_argv(mrb, obj, m_sym, 1, &amp;obj); // Calling ruby function from test.rb.
+   mrb_funcall_argv(mrb, obj, m_sym, <span style="color:#00D">1</span>, &amp;obj); <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">Calling</span> ruby function from test.rb.
    fclose(fp);
    mrb_close(mrb);
   }
@@ -4995,7 +5235,7 @@ Used inside a function of mrb_func_t type.</p>
         <span class='name'>mrb_value</span>
       
       
-        <span class='type'>(<tt>mrb_value</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></tt>)</span>
       
       
       
@@ -5010,7 +5250,7 @@ Used inside a function of mrb_func_t type.</p>
         <span class='name'>mrb_sym</span>
       
       
-        <span class='type'>(<tt>mrb_sym</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_sym-typedef" title="mrb_sym (typedef)">mrb_sym</a></span></tt>)</span>
       
       
       
@@ -5025,7 +5265,7 @@ Used inside a function of mrb_func_t type.</p>
         <span class='name'>mrb_int</span>
       
       
-        <span class='type'>(<tt><span class='object_link'><a href="#mrb_int-define" title="mrb_int (define)">mrb_int</a></span></tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_int-typedef" title="mrb_int (typedef)">mrb_int</a></span></tt>)</span>
       
       
       
@@ -5040,7 +5280,7 @@ Used inside a function of mrb_func_t type.</p>
         <span class='name'>mrb_value*</span>
       
       
-        <span class='type'>(<tt>const mrb_value*</tt>)</span>
+        <span class='type'>(<tt>const <span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span>*</tt>)</span>
       
       
       
@@ -5058,7 +5298,7 @@ Used inside a function of mrb_func_t type.</p>
     <li>
       
       
-        <span class='type'>(<tt>mrb_value</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></tt>)</span>
       
       
       
@@ -5078,6 +5318,8 @@ Used inside a function of mrb_func_t type.</p>
   </ul>
 
 </div>
+
+
 </div>
 
   
@@ -5098,6 +5340,8 @@ Used inside a function of mrb_func_t type.</p>
   
 
 </div>
+
+
 </div>
 
   
@@ -5109,13 +5353,13 @@ Used inside a function of mrb_func_t type.</p>
 </h3>
 <div class="docstring">
   <div class="discussion">
-    <p>Create a symbol</p>
+    <p>Creates a symbol from a C string.</p>
 
-<pre class="code ruby"><code class="ruby"># Ruby style:
-:pizza # =&gt; :pizza
+<pre class="code ruby"><code class="ruby"><span style="color:#777"># Ruby way:</span>
+<span style="color:#A60">:symbol</span> <span style="color:#777"># =&gt; :symbol</span>
 
-// C style:
-mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;pizza&quot;); //  =&gt; :pizza
+<span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">C</span> <span style="color:#606">way</span>:
+mrb_sym mrb_symbol = mrb_intern_cstr(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">symbol</span><span style="color:#710">&quot;</span></span>); <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span>  =&gt; <span style="color:#A60">:symbol</span>
 </code></pre>
 
 
@@ -5163,7 +5407,115 @@ mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;pizza&quot;); //  =&gt; :pizza
     <li>
       
       
-        <span class='type'>(<tt>mrb_sym</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_sym-typedef" title="mrb_sym (typedef)">mrb_sym</a></span></tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>mrb_sym A symbol.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+  <p class="tag_title">See Also:</p>
+  <ul class="see">
+    
+      <li><span class='object_link'><a href="#mrb_intern-function" title="mrb_intern (function)">mrb_intern</a></span></li>
+    
+  </ul>
+
+</div>
+
+
+</div>
+
+  
+    <div class="method_details ">
+  <h3 class="signature " id="mrb_intern-function">
+  mrb_sym <strong>mrb_intern</strong>(mrb_state* , const char* , size_t )
+
+  
+</h3>
+<div class="docstring">
+  <div class="discussion">
+    <p>Creates a symbol from a C string.</p>
+
+<pre class="code ruby"><code class="ruby"><span style="color:#777"># Ruby way</span>
+<span style="color:#A60">:symbol</span>
+
+<span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">C</span> way
+void
+mrb_mruby_example_gem_init(mrb_state* mrb) {
+  mrb_sym mrb_symbol;
+  char c_str[<span style="color:#00D">6</span>] = <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">symbol</span><span style="color:#710">&quot;</span></span>;
+
+  mrb_symbol = mrb_intern(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">symbol</span><span style="color:#710">&quot;</span></span>, sizeof(c_str));
+}
+</code></pre>
+
+
+  </div>
+</div>
+<div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>mrb_state*</span>
+      
+      
+        <span class='type'>(<tt>mrb_state*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>The current mruby state.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>const</span>
+      
+      
+        <span class='type'>(<tt>const char*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>char* A C string.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>size_t</span>
+      
+      
+        <span class='type'>(<tt>size_t</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>An integer representing the size of the string.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_sym-typedef" title="mrb_sym (typedef)">mrb_sym</a></span></tt>)</span>
       
       
       
@@ -5176,15 +5528,7 @@ mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;pizza&quot;); //  =&gt; :pizza
 </ul>
 
 </div>
-</div>
 
-  
-    <div class="method_details ">
-  <h3 class="signature " id="mrb_intern-function">
-  mrb_sym <strong>mrb_intern</strong>(mrb_state* , const char* , size_t )
-
-  
-</h3>
 
 </div>
 
@@ -5205,6 +5549,79 @@ mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;pizza&quot;); //  =&gt; :pizza
 
   
 </h3>
+<div class="docstring">
+  <div class="discussion">
+    <p>Creates a symbol from a String.</p>
+
+<pre class="code ruby"><code class="ruby">void
+mrb_mruby_example_gem_init(mrb_state* mrb) {
+  mrb_sym mrb_symbol;
+  mrb_value mrb_string;
+
+  mrb_string = mrb_str_new_cstr(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">symbol</span><span style="color:#710">&quot;</span></span>); <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">Returns</span> a <span style="color:#036;font-weight:bold">Ruby</span> string from <span style="color:#036;font-weight:bold">C</span> string.
+  mrb_intern_str(mrb, mrb_string); <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">Returns</span> <span style="color:#036;font-weight:bold">Symbol</span> from <span style="color:#036;font-weight:bold">Ruby</span> string.
+}
+</code></pre>
+
+
+  </div>
+</div>
+<div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>mrb_state*</span>
+      
+      
+        <span class='type'>(<tt>mrb_state*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>The current mruby state.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>mrb_value</span>
+      
+      
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>A Ruby value.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_sym-typedef" title="mrb_sym (typedef)">mrb_sym</a></span></tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>mrb_sym A symbol.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div>
+
 
 </div>
 
@@ -5215,6 +5632,78 @@ mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;pizza&quot;); //  =&gt; :pizza
 
   
 </h3>
+<div class="docstring">
+  <div class="discussion">
+    <p>Returns a Symbol, or nil otherwise.</p>
+
+<pre class="code ruby"><code class="ruby">void
+mrb_mruby_example_gem_init(mrb_state* mrb) {
+  mrb_value mrb_symbol;
+
+  mrb_symbol = mrb_check_intern_cstr(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">Symbol</span><span style="color:#710">&quot;</span></span>); <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">Returns</span> <span style="color:#A60">:Symbol</span>
+  mrb_p(mrb, mrb_symbol); <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">This</span> is equivalent to p <span style="color:#A60">:Symbol</span>
+}
+</code></pre>
+
+
+  </div>
+</div>
+<div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>mrb_state*</span>
+      
+      
+        <span class='type'>(<tt>mrb_state*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>The current mruby state.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>char*</span>
+      
+      
+        <span class='type'>(<tt>const char*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>A C string.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>mrb_value A Ruby value.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div>
+
 
 </div>
 
@@ -5235,6 +5724,80 @@ mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;pizza&quot;); //  =&gt; :pizza
 
   
 </h3>
+<div class="docstring">
+  <div class="discussion">
+    <p>Returns a Symbol, or nil otherwise.</p>
+
+<pre class="code ruby"><code class="ruby">void
+mrb_mruby_example_gem_init(mrb_state* mrb) {
+  mrb_value mrb_string;
+  mrb_value mrb_symbol;
+
+  mrb_string = mrb_str_new_cstr(mrb, <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">Symbol</span><span style="color:#710">&quot;</span></span>); <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">Returns</span> a <span style="color:#036;font-weight:bold">Ruby</span> string from <span style="color:#036;font-weight:bold">C</span> string.
+  mrb_symbol = mrb_check_intern_str(mrb, mrb_string); <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">Returns</span> <span style="color:#A60">:Symbol</span>
+  mrb_p(mrb, mrb_symbol); <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">This</span> is equivalent to p <span style="color:#A60">:Symbol</span>
+}
+</code></pre>
+
+
+  </div>
+</div>
+<div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>mrb_state*</span>
+      
+      
+        <span class='type'>(<tt>mrb_state*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>The current mruby state.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>mrb_value</span>
+      
+      
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>A Ruby value.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>mrb_value A Ruby value.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div>
+
 
 </div>
 
@@ -5245,6 +5808,81 @@ mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;pizza&quot;); //  =&gt; :pizza
 
   
 </h3>
+<div class="docstring">
+  <div class="discussion">
+    <p>Returns a String from a Symbol.</p>
+
+<pre class="code ruby"><code class="ruby">void
+mrb_mruby_example_gem_init(mrb_state* mrb) {
+  mrb_sym mrb_symbol;
+  mrb_value mrb_string;
+  const char* symbol_name = <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">symbol</span><span style="color:#710">&quot;</span></span>;
+
+  mrb_symbol = mrb_intern(mrb, symbol_name, strlen(symbol_name)); <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">Returns</span> <span style="color:#036;font-weight:bold">Symbol</span>.
+  mrb_string = mrb_sym2str(mrb, mrb_symbol); <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">Returns</span> symbol name as a <span style="color:#036;font-weight:bold">Ruby</span> string.
+  mrb_p(mrb, mrb_string);
+}
+</code></pre>
+
+
+  </div>
+</div>
+<div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>mrb_state*</span>
+      
+      
+        <span class='type'>(<tt>mrb_state*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>The current mruby state.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>mrb_sym</span>
+      
+      
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_sym-typedef" title="mrb_sym (typedef)">mrb_sym</a></span></tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>A Symbol.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>mrb_value A Ruby string value.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div>
+
 
 </div>
 
@@ -5252,6 +5890,79 @@ mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;pizza&quot;); //  =&gt; :pizza
     <div class="method_details ">
   <h3 class="signature " id="mrb_malloc-function">
   void * <strong>mrb_malloc</strong>(mrb_state* , size_t )
+
+  
+</h3>
+<div class="docstring">
+  <div class="discussion">
+    <p>Allocates the requested memory and returns a pointer to it. It raises RuntimeError if no memory.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>mrb_state*</span>
+      
+      
+        <span class='type'>(<tt>mrb_state*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>The current mruby state.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>size_t</span>
+      
+      
+        <span class='type'>(<tt>size_t</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>The size of memory block, in bytes.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>void*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>void* Pointer to requested block of memory.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div>
+
+
+</div>
+
+  
+    <div class="method_details ">
+  <h3 class="signature " id="mrb_calloc-function">
+  void * <strong>mrb_calloc</strong>(mrb_state* , size_t , size_t )
 
   
 </h3>
@@ -5266,26 +5977,8 @@ mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;pizza&quot;); //  =&gt; :pizza
   
 
 </div>
-</div>
-
-  
-    <div class="method_details ">
-  <h3 class="signature " id="mrb_calloc-function">
-  void * <strong>mrb_calloc</strong>(mrb_state* , size_t , size_t )
-
-  
-</h3>
-<div class="docstring">
-  <div class="discussion">
-    <p>ditto</p>
 
 
-  </div>
-</div>
-<div class="tags">
-  
-
-</div>
 </div>
 
   
@@ -5297,15 +5990,84 @@ mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;pizza&quot;); //  =&gt; :pizza
 </h3>
 <div class="docstring">
   <div class="discussion">
-    <p>ditto</p>
+    <p>Attempts to resize the memory block pointed to by ptr that was previously allocated with a call to mrb_malloc or mrb_calloc.
+It raises RuntimeError if no memory.</p>
 
 
   </div>
 </div>
 <div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
   
+    <li>
+      
+        <span class='name'>mrb_state*</span>
+      
+      
+        <span class='type'>(<tt>mrb_state*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>The current mruby state.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>void*</span>
+      
+      
+        <span class='type'>(<tt>void*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>This is the pointer to a memory block previously allocated with mrb_malloc or mrb_calloc.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>size_t</span>
+      
+      
+        <span class='type'>(<tt>size_t</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>The size of memory block, in bytes.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>void*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>void* Pointer to requested block of memory.</p>
+</div>
+      
+    </li>
+  
+</ul>
 
 </div>
+
+
 </div>
 
   
@@ -5317,15 +6079,84 @@ mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;pizza&quot;); //  =&gt; :pizza
 </h3>
 <div class="docstring">
   <div class="discussion">
-    <p>return NULL if no memory available</p>
+    <p>Attempts to resize the memory block pointed to by ptr that was previously allocated with a call to mrb_malloc_simple.
+It returns NULL if there&#39;s no memory available.</p>
 
 
   </div>
 </div>
 <div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
   
+    <li>
+      
+        <span class='name'>mrb_state*</span>
+      
+      
+        <span class='type'>(<tt>mrb_state*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>The current mruby state.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>void*</span>
+      
+      
+        <span class='type'>(<tt>void*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>This is the pointer to a memory block previously allocated with mrb_malloc_simple.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>size_t</span>
+      
+      
+        <span class='type'>(<tt>size_t</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>The size of memory block, in bytes.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>void*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>void* Pointer to requested block of memory.</p>
+</div>
+      
+    </li>
+  
+</ul>
 
 </div>
+
+
 </div>
 
   
@@ -5337,15 +6168,68 @@ mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;pizza&quot;); //  =&gt; :pizza
 </h3>
 <div class="docstring">
   <div class="discussion">
-    <p>return NULL if no memory available</p>
+    <p>Allocates the requested memory and returns a pointer to it. It return NULL if no memory available.</p>
 
 
   </div>
 </div>
 <div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
   
+    <li>
+      
+        <span class='name'>mrb_state*</span>
+      
+      
+        <span class='type'>(<tt>mrb_state*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>The current mruby state.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>size_t</span>
+      
+      
+        <span class='type'>(<tt>size_t</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>The size of memory block, in bytes.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>void*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>void* Pointer to requested block of memory.</p>
+</div>
+      
+    </li>
+  
+</ul>
 
 </div>
+
+
 </div>
 
   
@@ -5355,17 +6239,7 @@ mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;pizza&quot;); //  =&gt; :pizza
 
   
 </h3>
-<div class="docstring">
-  <div class="discussion">
-    <p>return NULL if no memory available</p>
 
-
-  </div>
-</div>
-<div class="tags">
-  
-
-</div>
 </div>
 
   
@@ -5375,6 +6249,52 @@ mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;pizza&quot;); //  =&gt; :pizza
 
   
 </h3>
+<div class="docstring">
+  <div class="discussion">
+    <p>Deallocates the memory previously allocated by a call to mrb_calloc, mrb_malloc, mrb_realloc, mrb_malloc_simple, or mrb_realloc_simple</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>mrb_state*</span>
+      
+      
+        <span class='type'>(<tt>mrb_state*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>The current mruby state.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>void*</span>
+      
+      
+        <span class='type'>(<tt>void*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>The pointer to a memory block previously allocated.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+
+</div>
+
 
 </div>
 
@@ -5385,6 +6305,94 @@ mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;pizza&quot;); //  =&gt; :pizza
 
   
 </h3>
+<div class="docstring">
+  <div class="discussion">
+    <p>Returns a String from C String.</p>
+
+<pre class="code ruby"><code class="ruby">void
+mrb_mruby_example_gem_init(mrb_state* mrb) {
+  mrb_value mrb_string;
+  char c_str[<span style="color:#00D">6</span>] = <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">String</span><span style="color:#710">&quot;</span></span>;
+
+  mrb_string = mrb_str_new(mrb, c_str, strlen(c_str)); <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">Return</span> <span style="color:#036;font-weight:bold">Ruby</span> string value.
+  mrb_p(mrb, mrb_string);
+}
+</code></pre>
+
+
+  </div>
+</div>
+<div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>mrb</span>
+      
+      
+        <span class='type'>(<tt>mrb_state*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>The current mruby state.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>*p</span>
+      
+      
+        <span class='type'>(<tt>const char</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>A C string.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>len</span>
+      
+      
+        <span class='type'>(<tt>size_t</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>The length of string.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>mrb_value A Ruby value.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div>
+
 
 </div>
 
@@ -5397,15 +6405,78 @@ mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;pizza&quot;); //  =&gt; :pizza
 </h3>
 <div class="docstring">
   <div class="discussion">
-    <p>Turns a C string into a Ruby string value.</p>
+    <p>Returns a String from a C string.</p>
+
+<pre class="code ruby"><code class="ruby">void
+mrb_mruby_example_gem_init(mrb_state* mrb) {
+  mrb_value mrb_string;
+  char c_str[<span style="color:#00D">6</span>] = <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">String</span><span style="color:#710">&quot;</span></span>;
+
+  mrb_string = mrb_str_new_cstr(mrb, c_str); <span style="background-color:hsla(300,100%,50%,0.06)"><span style="color:#404">/</span><span style="color:#404">/</span></span> <span style="color:#036;font-weight:bold">Return</span> <span style="color:#036;font-weight:bold">Ruby</span> string value.
+  mrb_p(mrb, mrb_string);
+}
+</code></pre>
 
 
   </div>
 </div>
 <div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
   
+    <li>
+      
+        <span class='name'>mrb</span>
+      
+      
+        <span class='type'>(<tt>mrb_state*</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>The current mruby state.</p>
+</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>*p</span>
+      
+      
+        <span class='type'>(<tt>const char</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>A C string.</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt><span class='object_link'><a href="mruby_2Fvalue.h.html#mrb_value-typedef" title="mrb_value (typedef)">mrb_value</a></span></tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'><p>mrb_value A Ruby value.</p>
+</div>
+      
+    </li>
+  
+</ul>
 
 </div>
+
+
 </div>
 
   
@@ -5453,6 +6524,8 @@ mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;pizza&quot;); //  =&gt; :pizza
 </ul>
 
 </div>
+
+
 </div>
 
   
@@ -5499,7 +6572,7 @@ mrb_sym m_sym = mrb_intern_cstr(mrb, &quot;pizza&quot;); //  =&gt; :pizza
       
         &mdash;
         <div class='inline'><p>User data will be passed to custom allocator f.
-If user data isn’t required just pass NULL.</p>
+If user data isn&#39;t required just pass NULL.</p>
 </div>
       
     </li>
@@ -5525,6 +6598,8 @@ If user data isn’t required just pass NULL.</p>
 </ul>
 
 </div>
+
+
 </div>
 
   
@@ -5572,7 +6647,7 @@ Use mrb_default_allocf for the default</p>
       
         &mdash;
         <div class='inline'><p>User data will be passed to custom allocator f.
-If user data isn’t required just pass NULL.</p>
+If user data isn&#39;t required just pass NULL.</p>
 </div>
       
     </li>
@@ -5598,6 +6673,8 @@ If user data isn’t required just pass NULL.</p>
 </ul>
 
 </div>
+
+
 </div>
 
   
@@ -5637,6 +6714,8 @@ If user data isn’t required just pass NULL.</p>
 
 
 </div>
+
+
 </div>
 
   
@@ -5664,6 +6743,8 @@ If user data isn’t required just pass NULL.</p>
   </ul>
 
 </div>
+
+
 </div>
 
   
@@ -5688,8 +6769,8 @@ If user data isn’t required just pass NULL.</p>
 
   
     <div class="method_details ">
-  <h3 class="signature " id="mrb_toplevel_run-function">
-  mrb_value <strong>mrb_toplevel_run</strong>(mrb_state* , struct RProc* )
+  <h3 class="signature " id="mrb_top_run-function">
+  mrb_value <strong>mrb_top_run</strong>(mrb_state* , struct RProc* , mrb_value , unsigned int)
 
   
 </h3>
@@ -5698,8 +6779,18 @@ If user data isn’t required just pass NULL.</p>
 
   
     <div class="method_details ">
-  <h3 class="signature " id="mrb_context_run-function">
-  mrb_value <strong>mrb_context_run</strong>(mrb_state* , struct RProc* , mrb_value , unsigned int)
+  <h3 class="signature " id="mrb_vm_run-function">
+  mrb_value <strong>mrb_vm_run</strong>(mrb_state* , struct RProc* , mrb_value , unsigned int)
+
+  
+</h3>
+
+</div>
+
+  
+    <div class="method_details ">
+  <h3 class="signature " id="mrb_vm_exec-function">
+  mrb_value <strong>mrb_vm_exec</strong>(mrb_state* , struct RProc* , mrb_code* )
 
   
 </h3>
@@ -6114,6 +7205,8 @@ If user data isn’t required just pass NULL.</p>
   
 
 </div>
+
+
 </div>
 
   
@@ -6134,6 +7227,8 @@ If user data isn’t required just pass NULL.</p>
   
 
 </div>
+
+
 </div>
 
   
@@ -6154,6 +7249,8 @@ If user data isn’t required just pass NULL.</p>
   
 
 </div>
+
+
 </div>
 
   
@@ -6244,6 +7341,10 @@ If user data isn’t required just pass NULL.</p>
   
 
 </div>
+
+	<p class="tag_title"><strong>Required mrbgem</strong>: mruby-fiber</p>
+
+
 </div>
 
   
@@ -6264,6 +7365,10 @@ If user data isn’t required just pass NULL.</p>
   
 
 </div>
+
+	<p class="tag_title"><strong>Required mrbgem</strong>: mruby-fiber</p>
+
+
 </div>
 
   
@@ -6371,9 +7476,9 @@ If user data isn’t required just pass NULL.</p>
 </div>
 
     <div id="footer">
-  Generated on Mon Dec 14 14:10:53 2015 by
+  Generated on Mon Jan 11 15:22:57 2016 by
   <a href="http://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.8.7.6 in <a href="https://github.com/sagmor/yard-mruby">mruby mode</a> 0.2.0 (ruby-2.2.3).
+  0.8.7.6 in <a href="https://github.com/sagmor/yard-mruby">mruby mode</a> 0.2.1 (ruby-2.3.0).
 </div>
 
   </body>


### PR DESCRIPTION
What exactly is the difference between mrb_str_new(), and mrb_str_new_ctr()? mrb_str_new_ctr() seems to just be shorthand for mrb_str_new(). So when I wrote the docs for those two I gave them the same description.