### PR TITLE
exclude vendor direcroty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 _site
 mruby
+/.bundle/
+/vendor/

--- a/_config.yml
+++ b/_config.yml
@@ -6,3 +6,4 @@ exclude:
 - Gemfile.lock
 - README.md
 - gen_mgemdata.rb
+- vendor


### PR DESCRIPTION
`vendor` directory is often used by `bundle install --path vendor/bundle`.