### PR TITLE
Set download links to 1.4.1.

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -7,7 +7,7 @@ title: mruby - downloads
   <div>
     <h2>Downloads</h2>
     <p>
-      <b>Current stable</b>: <a href="https://github.com/mruby/mruby/archive/1.3.0.zip">mruby 1.3.0</a>
+      <b>Current stable</b>: <a href="https://github.com/mruby/mruby/archive/1.4.1.zip">mruby 1.4.1</a>
     </p>
   </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ title: mruby
     </p>
 
     <div class="mruby-is-get">
-      <a href="https://github.com/mruby/mruby/archive/1.3.0.zip" class="btn btn-lg btn-default" role="button">Download 1.3.0 Source</a>
+      <a href="https://github.com/mruby/mruby/archive/1.4.1.zip" class="btn btn-lg btn-default" role="button">Download 1.4.1 Source</a>
       &nbsp; or &nbsp;
       <a href="https://github.com/mruby/mruby" class="btn btn-lg btn-default" role="button">Find on GitHub</a>
     </div>


### PR DESCRIPTION
Sets the download link in the header menu and on the mruby.org homepage to the 1.4.1 release.