### PR TITLE
Checkout $1 as git-ref if it is provided.

### DIFF
--- a/gen/api
+++ b/gen/api
@@ -13,6 +13,14 @@ else
 	git clone https://github.com/mruby/mruby.git
 fi
 
+# Treat argument as ref if provided.
+# Can be used to generate documentation for a specific release.
+if [ -n $1 ]; then
+	pushd mruby
+	git checkout $1
+	popd
+fi
+
 # Clean old docs
 rm -rf docs/api
 


### PR DESCRIPTION
I'm not sure whether it will be useful enough to commit but I used this modification to generate docs for 1.4.1 for #5 rather than the current trunk.