### PR TITLE
Fix a broken link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 name: mruby
 markdown: kramdown
 highlighter: rouge
+include: _index.html
 exclude:
 - Gemfile
 - Gemfile.lock


### PR DESCRIPTION
`_index.html ` as file name can't use in GitHub Pages.

https://help.github.com/en/articles/files-that-start-with-an-underscore-are-missing

This PR is work around.

A part of a fix for issue #50