### PR TITLE
Add Jekyll Sitemap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,10 @@
 source 'https://rubygems.org'
 
-gem 'github-pages'
+gem 'github-pages', group: :jekyll_plugins
+
+group :jekyll_plugins do
+  gem 'jekyll-sitemap'
+end
 
 group :scripts do 
   gem 'mgem' 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,6 +266,7 @@ PLATFORMS
 DEPENDENCIES
   git
   github-pages
+  jekyll-sitemap
   mgem
   yard-coderay
   yard-mruby

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,8 @@ highlighter: rouge
 url: https://mruby.org
 repository: https://github.com/mruby/mruby.github.io
 include: _index.html
+plugins:
+  - jekyll-sitemap
 exclude:
 - Gemfile
 - Gemfile.lock


### PR DESCRIPTION
This creates both a `sitemap.xml` and a `robots.txt` file in the web root

https://github.com/jekyll/jekyll-sitemap

<img width="342" alt="Screen Shot 2020-12-24 at 9 59 09 am" src="https://user-images.githubusercontent.com/418747/103045795-9f6af380-45d1-11eb-961f-a07e0b42e056.png">

<img width="687" alt="Screen Shot 2020-12-24 at 10 00 42 am" src="https://user-images.githubusercontent.com/418747/103045809-a98cf200-45d1-11eb-8d09-807d867adb15.png">
